### PR TITLE
SentryOutputWriter support

### DIFF
--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -16,23 +16,23 @@ package heka_mozsvc_plugins
 
 import (
 	"github.com/rafrombrc/gospec/src/gospec"
-	. "heka/pipeline"
+	"heka/pipeline"
 	"testing"
 )
 
-func mockDecoderCreator() map[string]Decoder {
-	return make(map[string]Decoder)
+func mockDecoderCreator() map[string]pipeline.Decoder {
+	return make(map[string]pipeline.Decoder)
 }
 
-func mockFilterCreator() map[string]Filter {
-	return make(map[string]Filter)
+func mockFilterCreator() map[string]pipeline.Filter {
+	return make(map[string]pipeline.Filter)
 }
 
-func mockOutputCreator() map[string]Output {
-	return make(map[string]Output)
+func mockOutputCreator() map[string]pipeline.Output {
+	return make(map[string]pipeline.Output)
 }
 
-var config = PipelineConfig{DefaultDecoder: "TEST", DefaultFilterChain: "TEST"}
+var config = pipeline.PipelineConfig{DefaultDecoder: "TEST", DefaultFilterChain: "TEST"}
 
 func TestAllSpecs(t *testing.T) {
 	r := gospec.NewRunner()
@@ -43,6 +43,6 @@ func TestAllSpecs(t *testing.T) {
 	gospec.MainGoTest(r, t)
 }
 
-func getTestPipelinePack() *PipelinePack {
-	return NewPipelinePack(&config)
+func getTestPipelinePack() *pipeline.PipelinePack {
+	return pipeline.NewPipelinePack(&config)
 }

--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -39,7 +39,7 @@ func TestAllSpecs(t *testing.T) {
 	r.Parallel = false
 
 	r.AddSpec(StatsdOutWriterSpec)
-	r.AddSpec(SentryOutWriterSpec)
+	r.AddSpec(SentryOutputSpec)
 
 	gospec.MainGoTest(r, t)
 }

--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -39,6 +39,7 @@ func TestAllSpecs(t *testing.T) {
 	r.Parallel = false
 
 	r.AddSpec(StatsdOutWriterSpec)
+	r.AddSpec(SentryOutWriterSpec)
 
 	gospec.MainGoTest(r, t)
 }

--- a/outputs.go
+++ b/outputs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mozilla-services/heka/pipeline"
 	"log"
 	"log/syslog"
+    "time"
 )
 
 var (
@@ -68,7 +69,7 @@ func (self *CefWriter) ZeroOutData(outData interface{}) {
 	syslogMsg.priority = syslog.LOG_INFO
 }
 
-func (self *CefWriter) PrepOutData(pack *pipeline.PipelinePack, outData interface{}) {
+func (self *CefWriter) PrepOutData(pack *pipeline.PipelinePack, outData interface{}, timeout *time.Duration) {
 	// For b/w compatibility reasons the priority info is stored as a string
 	// and we have to look it up in the SYSLOG_PRIORITY map. In the future
 	// we should be storing the priority integer value directly to avoid the

--- a/sentry.go
+++ b/sentry.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"github.com/mozilla-services/heka/pipeline"
 	"log"
-	"net"
+	//	"net"
 	"net/url"
 	"time"
 )
@@ -41,12 +41,15 @@ func hmac_sha1(message, key []byte) string {
 
 type SentryMsg struct {
 	encoded_payload string
-	epoch_timestamp string
+	epoch_ts64      float64
+	epoch_time      time.Time
 	dsn             string
 	parsed_dsn      *url.URL
 	auth_header     string
-	prep_error      error
 	headers         map[string]string
+
+	prep_error error
+	prep_bool  bool
 
 	// TODO: i think this might be the only thing we really need
 	data_packet []byte
@@ -71,33 +74,17 @@ func get_auth_header(protocol float32, signature string, timestamp string, clien
 	return fmt.Sprintf(header_tmpl, timestamp, client_id, protocol, api_key)
 }
 
-func get_signature(message, timestamp, key string) string {
-	return hmac_sha1([]byte(fmt.Sprintf("%s %s", timestamp, message)), []byte(key))
+func get_signature(message string, str_ts string, key string) string {
+	return hmac_sha1([]byte(fmt.Sprintf("%s %s", str_ts, message)), []byte(key))
 }
 
-func send(event map[string]interface{}) {
-	message := event["payload"].(string)
-	field_map := event["fields"].(map[string]interface{})
-	timestamp := field_map["epoch_timestamp"].(string)
-	dsn := field_map["dsn"].(string)
+type PrepOutDataError struct {
+	When time.Time
+	What string
+}
 
-	dsn_uri, err := url.Parse(dsn)
-	if err != nil {
-		// TODO: log an error for an invalid DSN
-		return
-	}
-
-	headers, err := compute_headers(message, dsn_uri, timestamp)
-	if err != nil {
-		// TODO: log an error for an invalid DSN
-		return
-	}
-
-	auth_header := headers["X-Sentry-Auth"]
-
-	// TODO: pull the socket up and out into something we can mock
-	conn, err := net.Dial("udp", dsn_uri.Host)
-	conn.Write([]byte(fmt.Sprintf("%s\n\n%s", auth_header, message)))
+func (e PrepOutDataError) Error() string {
+	return fmt.Sprintf("%v: %v", e.When, e.What)
 }
 
 type MissingPassword struct {
@@ -107,7 +94,7 @@ func (e MissingPassword) Error() string {
 	return "No password was found in the DSN URI"
 }
 
-func compute_headers(message string, uri *url.URL, timestamp string) (map[string]string, error) {
+func compute_headers(message string, uri *url.URL, timestamp time.Time) (map[string]string, error) {
 
 	password, ok := uri.User.Password()
 	if !ok {
@@ -115,9 +102,14 @@ func compute_headers(message string, uri *url.URL, timestamp string) (map[string
 	}
 
 	headers := make(map[string]string)
+
+	// TODO: str_ts needs to be pulled into the sentryMsg
+	var str_ts string
+	str_ts = timestamp.Format(time.RFC3339Nano)
+
 	headers["X-Sentry-Auth"] = get_auth_header(2.0,
-		get_signature(message, timestamp, password),
-		timestamp,
+		get_signature(message, str_ts, password),
+		str_ts,
 		"raven-go/1.0",
 		uri.User.Username())
 
@@ -139,7 +131,7 @@ func (self *SentryOutWriter) MakeOutData() interface{} {
 	// TODO: pretty sure that we don't actually need to store *all*
 	// the headers, just a single one
 	headers := make(map[string]string)
-	return SentryMsg{data_packet: raw_bytes, headers: headers}
+	return &SentryMsg{data_packet: raw_bytes, headers: headers}
 }
 
 func (self *SentryOutWriter) ZeroOutData(outData interface{}) {
@@ -149,10 +141,20 @@ func (self *SentryOutWriter) ZeroOutData(outData interface{}) {
 }
 
 func (self *SentryOutWriter) PrepOutData(pack *pipeline.PipelinePack, outData interface{}, timeout *time.Duration) error {
+
 	sentryMsg := outData.(*SentryMsg)
 
 	sentryMsg.encoded_payload = pack.Message.Payload
-	sentryMsg.epoch_timestamp = pack.Message.Fields["epoch_timestamp"].(string)
+
+	sentryMsg.epoch_ts64, sentryMsg.prep_bool = pack.Message.Fields["epoch_timestamp"].(float64)
+
+	if !sentryMsg.prep_bool {
+		log.Printf("Error parsing epoch_timestamp")
+		return PrepOutDataError{time.Now(), "Error parsing epoch_timestamp"}
+	}
+
+	sentryMsg.epoch_time = time.Unix(int64(sentryMsg.epoch_ts64),
+		int64((sentryMsg.epoch_ts64-float64(int64(sentryMsg.epoch_ts64)))*1e9))
 
 	sentryMsg.dsn = pack.Message.Fields["dsn"].(string)
 
@@ -164,7 +166,7 @@ func (self *SentryOutWriter) PrepOutData(pack *pipeline.PipelinePack, outData in
 
 	sentryMsg.headers, sentryMsg.prep_error = compute_headers(sentryMsg.encoded_payload,
 		sentryMsg.parsed_dsn,
-		sentryMsg.epoch_timestamp)
+		sentryMsg.epoch_time)
 
 	if sentryMsg.prep_error != nil {
 		log.Printf("Invalid DSN: [%s]", sentryMsg.dsn)
@@ -176,6 +178,7 @@ func (self *SentryOutWriter) PrepOutData(pack *pipeline.PipelinePack, outData in
 	// TODO: i think the data_packet is the only thing we really need
 	// to keep track of is the data_packet and the UDP host/port
 	sentryMsg.data_packet = []byte(fmt.Sprintf("%s\n\n%s", sentryMsg.auth_header, sentryMsg.encoded_payload))
+	//fmt.Printf("Preped data packet!: %s\n", string(sentryMsg.data_packet))
 
 	return nil
 }
@@ -184,11 +187,13 @@ func (self *SentryOutWriter) Write(outData interface{}) (err error) {
 	self.sentryMsg = outData.(*SentryMsg)
 
 	// TODO: pull the socket up and out into something we can mock
-	conn, err := net.Dial("udp", self.sentryMsg.parsed_dsn.Host)
-	conn.Write(self.sentryMsg.data_packet)
+	fmt.Printf("UDP Out some data: [%s]\n", self.sentryMsg.data_packet)
+	//conn, err := net.Dial("udp", self.sentryMsg.parsed_dsn.Host)
+	//conn.Write(self.sentryMsg.data_packet)
 	return
 }
 
 func (self *SentryOutWriter) Event(eventType string) {
 	// Don't need to do anything here as sentry is just UDP
+	// so we don't need to respond to RELOAD or STOP requests
 }

--- a/sentry.go
+++ b/sentry.go
@@ -54,18 +54,18 @@ type SentryMsg struct {
 	data_packet []byte
 }
 
-type SentryOutWriter struct {
+type SentryOutput struct {
 	DSN       string
 	sentryMsg *SentryMsg
 }
 
-type SentryOutWriterConfig struct {
+type SentryOutputConfig struct {
 	DSN string
 }
 
-func (self *SentryOutWriter) ConfigStruct() interface{} {
+func (self *SentryOutput) ConfigStruct() interface{} {
 	// Default the statsd output to localhost port 5555
-	return &SentryOutWriterConfig{DSN: "udp://mockuser:mockpassword@localhost:5565"}
+	return &SentryOutputConfig{DSN: "udp://mockuser:mockpassword@localhost:5565"}
 }
 
 func get_auth_header(protocol float32, signature string, timestamp string, client_id string, api_key string) string {
@@ -111,25 +111,25 @@ func compute_headers(message string, uri *url.URL, timestamp time.Time) (string,
 		uri.User.Username()), nil
 }
 
-func (self *SentryOutWriter) Init(config interface{}) (err error) {
-	conf := config.(*SentryOutWriterConfig)
+func (self *SentryOutput) Init(config interface{}) (err error) {
+	conf := config.(*SentryOutputConfig)
 	self.DSN = conf.DSN
 	return nil
 }
 
-func (self *SentryOutWriter) MakeOutData() interface{} {
+func (self *SentryOutput) MakeOutData() interface{} {
 	raw_bytes := make([]byte, 0, MAX_SENTRY_BYTES)
 
 	return &SentryMsg{data_packet: raw_bytes}
 }
 
-func (self *SentryOutWriter) ZeroOutData(outData interface{}) {
+func (self *SentryOutput) ZeroOutData(outData interface{}) {
 	// Just zero out the byte array
 	msg := outData.(*SentryMsg)
 	msg.data_packet = msg.data_packet[:0]
 }
 
-func (self *SentryOutWriter) PrepOutData(pack *pipeline.PipelinePack, outData interface{}, timeout *time.Duration) error {
+func (self *SentryOutput) PrepOutData(pack *pipeline.PipelinePack, outData interface{}, timeout *time.Duration) error {
 
 	sentryMsg := outData.(*SentryMsg)
 
@@ -170,7 +170,7 @@ func (self *SentryOutWriter) PrepOutData(pack *pipeline.PipelinePack, outData in
 	return nil
 }
 
-func (self *SentryOutWriter) Write(outData interface{}) (err error) {
+func (self *SentryOutput) Write(outData interface{}) (err error) {
 	self.sentryMsg = outData.(*SentryMsg)
 	// TODO: add a resolveaddr call here
 	// TODO: pull up the socket into something we can stub out for
@@ -180,7 +180,7 @@ func (self *SentryOutWriter) Write(outData interface{}) (err error) {
 	return nil
 }
 
-func (self *SentryOutWriter) Event(eventType string) {
+func (self *SentryOutput) Event(eventType string) {
 	// Don't need to do anything here as sentry is just UDP
 	// so we don't need to respond to RELOAD or STOP requests
 }

--- a/sentry.go
+++ b/sentry.go
@@ -58,17 +58,15 @@ type SentryMsg struct {
 }
 
 type SentryOutputWriter struct {
-	DSN       string
 	sentryMsg *SentryMsg
 }
 
 type SentryOutputConfig struct {
-	DSN string
 }
 
 func (self *SentryOutputWriter) ConfigStruct() interface{} {
 	// Default the statsd output to localhost port 5555
-	return &SentryOutputConfig{DSN: "udp://mockuser:mockpassword@localhost:5565"}
+	return &SentryOutputConfig{}
 }
 
 func get_auth_header(protocol float32, signature string, timestamp string, client_id string, api_key string) string {
@@ -115,8 +113,6 @@ func compute_headers(message string, uri *url.URL, timestamp time.Time) (string,
 }
 
 func (self *SentryOutputWriter) Init(config interface{}) error {
-	conf := config.(*SentryOutputConfig)
-	self.DSN = conf.DSN
 	return nil
 }
 

--- a/sentry.go
+++ b/sentry.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"github.com/mozilla-services/heka/pipeline"
 	"log"
-	//	"net"
+	"net"
 	"net/url"
 	"time"
 )
@@ -185,12 +185,12 @@ func (self *SentryOutWriter) PrepOutData(pack *pipeline.PipelinePack, outData in
 
 func (self *SentryOutWriter) Write(outData interface{}) (err error) {
 	self.sentryMsg = outData.(*SentryMsg)
-
-	// TODO: pull the socket up and out into something we can mock
-	fmt.Printf("UDP Out some data: [%s]\n", self.sentryMsg.data_packet)
-	//conn, err := net.Dial("udp", self.sentryMsg.parsed_dsn.Host)
-	//conn.Write(self.sentryMsg.data_packet)
-	return
+	// TODO: add a resolveaddr call here
+	// TODO: pull up the socket into something we can stub out for
+	// testing
+	conn, err := net.Dial("udp", self.sentryMsg.parsed_dsn.Host)
+	conn.Write(self.sentryMsg.data_packet)
+	return nil
 }
 
 func (self *SentryOutWriter) Event(eventType string) {

--- a/sentry.go
+++ b/sentry.go
@@ -1,0 +1,67 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2012
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Victor Ng (vng@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package heka_mozsvc_plugins
+
+import "crypto/hmac"
+import "crypto/sha1"
+import "encoding/hex"
+import "net/url"
+import "fmt"
+
+// CheckMAC returns true if messageMAC is a valid HMAC tag for
+// message.
+func hmac_sha1(message, key []byte) string {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+	return hex.EncodeToString(expectedMAC)
+}
+
+type SentryOutWriterConfig struct {
+	DSN string
+}
+
+type SentryOutWriter struct {
+	DSN string
+}
+
+func (self *SentryOutWriter) get_auth_header(protocol float32, signature string, timestamp string, client_id string, api_key string) string {
+	header_tmpl := "Sentry sentry_timestamp=%s, sentry_client=%s, sentry_version=%0.1f, sentry_key=%s"
+	return fmt.Sprintf(header_tmpl, timestamp, client_id, protocol, api_key)
+}
+
+func (self *SentryOutWriter) compute_headers(message string, uri url.URL, timestamp string) (map[string]string, bool) {
+
+	// TODO: uncomment
+	//password, ok := uri.User.Password()
+	//if !ok {
+	//return nil, ok
+	//}
+
+	//client_version := 1.0
+
+	headers := make(map[string]string)
+	headers["X-Sentry-Auth"] = "blah"
+	//get_auth_header( protocol=2.0, signature=get_signature(message, timestamp, password), timestamp=timestamp, client_id="raven-logstash/#{client_version}", api_key=uri.user)
+	headers["Content-Type"] = "application/octet-stream"
+	return headers, true
+}
+
+func (self *SentryOutWriter) Init(config interface{}) (err error) {
+	conf := config.(*SentryOutWriterConfig)
+	self.DSN = conf.DSN
+	// TODO: instantiate the actual raven client
+	return nil
+}

--- a/sentry.go
+++ b/sentry.go
@@ -26,8 +26,10 @@ import (
 	"time"
 )
 
+// TODO: pull this out into a configstruct
 const (
 	MAX_SENTRY_BYTES = 64000
+	MAX_UDP_SOCKETS  = 20
 )
 
 // CheckMAC returns true if messageMAC is a valid HMAC tag for
@@ -166,6 +168,9 @@ func (self *SentryOutputWriter) Write(outData interface{}) (err error) {
 	self.udp_addr_str = self.sentryMsg.parsed_dsn.Host
 	self.socket, self.host_ok = self.udpMap[self.udp_addr_str]
 	if !self.host_ok {
+		if len(self.udpMap) > MAX_UDP_SOCKETS {
+			return PrepOutDataError{time.Now(), "Maximum number of UDP sockets reached."}
+		}
 
 		self.udp_addr, self.socket_err = net.ResolveUDPAddr("udp", self.udp_addr_str)
 		if err != nil {

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -15,20 +15,10 @@
 package heka_mozsvc_plugins
 
 import (
-	"fmt"
-	"github.com/mozilla-services/heka/pipeline"
 	gs "github.com/rafrombrc/gospec/src/gospec"
 )
 
 func SentryOutputSpec(c gs.Context) {
-	c.Specify("verify all interfaces are met with this plugin", func() {
-		var obj interface{}
-		x := &SentryOutputWriter{}
-		obj = pipeline.Plugin(x)
-		obj = pipeline.Writer(x)
-		fmt.Printf("%s %s %s\n", x, obj)
-	})
-
 	c.Specify("check that hmac hashes are correct", func() {
 
 		// The following hexdigest was verified using a Python
@@ -63,9 +53,5 @@ func SentryOutputSpec(c gs.Context) {
 
 		c.Expect(actual_sig, gs.Equals, expected_sig)
 	})
-
-    c.Specify("check UDP wire data", func() {
-        // TODO:
-    })
 
 }

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -64,4 +64,8 @@ func SentryOutputSpec(c gs.Context) {
 		c.Expect(actual_sig, gs.Equals, expected_sig)
 	})
 
+    c.Specify("check UDP wire data", func() {
+        // TODO:
+    })
+
 }

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -19,9 +19,9 @@ import (
     "fmt"
 )
 
-func SentryOutWriterSpec(c gs.Context) {
+func SentryOutputSpec(c gs.Context) {
 	c.Specify("verify all interfaces are met with this plugin", func() {
-		x := SentryOutWriter{}
+		x := SentryOutput{}
         fmt.Printf("%s", x)
 	})
 

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -1,0 +1,40 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2012
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Victor Ng (vng@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package heka_mozsvc_plugins
+
+import (
+	gs "github.com/rafrombrc/gospec/src/gospec"
+)
+
+func SentryOutWriterSpec(c gs.Context) {
+	c.Specify("check that hmac hashes are correct", func() {
+
+		// The following hexdigest was verified using a Python
+		// hmac-sha1 snippet:
+		//      hmac.new('this is the key', 'foobar', sha1).hexdigest()
+		//      'c7cbdca495adb024647b64123ef8203ae333f0d6'
+		expected_hexdigest := "c7cbdca495adb024647b64123ef8203ae333f0d6"
+
+		actual_hexdigest := hmac_sha1([]byte("foobar"), []byte("this is the key"))
+		c.Expect(actual_hexdigest, gs.Equals, expected_hexdigest)
+	})
+
+	c.Specify("check auth header", func() {
+		writer := new(SentryOutWriter)
+		actual_header := writer.get_auth_header(2.0, "some_sig", "some_time", "some_client", "some_api_key")
+		expected_header := "Sentry sentry_timestamp=some_time, sentry_client=some_client, sentry_version=2.0, sentry_key=some_api_key"
+		c.Expect(actual_header, gs.Equals, expected_header)
+	})
+}

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -16,9 +16,15 @@ package heka_mozsvc_plugins
 
 import (
 	gs "github.com/rafrombrc/gospec/src/gospec"
+    "fmt"
 )
 
 func SentryOutWriterSpec(c gs.Context) {
+	c.Specify("verify all interfaces are met with this plugin", func() {
+		x := SentryOutWriter{}
+        fmt.Printf("%s", x)
+	})
+
 	c.Specify("check that hmac hashes are correct", func() {
 
 		// The following hexdigest was verified using a Python
@@ -39,14 +45,14 @@ func SentryOutWriterSpec(c gs.Context) {
 
 	c.Specify("check signature", func() {
 		/*
-		The expected_sig here is computed using:
+					The expected_sig here is computed using:
 
-        In [8]: def getsig(m, t, k):
-           ...:   return hmac.new(k, '%s %s' % (t, m), sha1).hexdigest()
-           ...:
+			        In [8]: def getsig(m, t, k):
+			           ...:   return hmac.new(k, '%s %s' % (t, m), sha1).hexdigest()
+			           ...:
 
-		In [9]: getsig('a message', 'some_time', 'some_api_key')
-		Out[9]: 'c05d61d5a04b6b37e122792b2eb9ccc6436441dc'
+					In [9]: getsig('a message', 'some_time', 'some_api_key')
+					Out[9]: 'c05d61d5a04b6b37e122792b2eb9ccc6436441dc'
 		*/
 		actual_sig := get_signature("a message", "some_time", "some_api_key")
 		expected_sig := "c05d61d5a04b6b37e122792b2eb9ccc6436441dc"

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -15,14 +15,18 @@
 package heka_mozsvc_plugins
 
 import (
+	"fmt"
+	"github.com/mozilla-services/heka/pipeline"
 	gs "github.com/rafrombrc/gospec/src/gospec"
-    "fmt"
 )
 
 func SentryOutputSpec(c gs.Context) {
 	c.Specify("verify all interfaces are met with this plugin", func() {
-		x := SentryOutput{}
-        fmt.Printf("%s", x)
+		var obj interface{}
+		x := &SentryOutputWriter{}
+		obj = pipeline.Plugin(x)
+		obj = pipeline.Writer(x)
+		fmt.Printf("%s %s %s\n", x, obj)
 	})
 
 	c.Specify("check that hmac hashes are correct", func() {

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -32,9 +32,26 @@ func SentryOutWriterSpec(c gs.Context) {
 	})
 
 	c.Specify("check auth header", func() {
-		writer := new(SentryOutWriter)
-		actual_header := writer.get_auth_header(2.0, "some_sig", "some_time", "some_client", "some_api_key")
+		actual_header := get_auth_header(2.0, "some_sig", "some_time", "some_client", "some_api_key")
 		expected_header := "Sentry sentry_timestamp=some_time, sentry_client=some_client, sentry_version=2.0, sentry_key=some_api_key"
 		c.Expect(actual_header, gs.Equals, expected_header)
 	})
+
+	c.Specify("check signature", func() {
+		/*
+		The expected_sig here is computed using:
+
+        In [8]: def getsig(m, t, k):
+           ...:   return hmac.new(k, '%s %s' % (t, m), sha1).hexdigest()
+           ...:
+
+		In [9]: getsig('a message', 'some_time', 'some_api_key')
+		Out[9]: 'c05d61d5a04b6b37e122792b2eb9ccc6436441dc'
+		*/
+		actual_sig := get_signature("a message", "some_time", "some_api_key")
+		expected_sig := "c05d61d5a04b6b37e122792b2eb9ccc6436441dc"
+
+		c.Expect(actual_sig, gs.Equals, expected_sig)
+	})
+
 }


### PR DESCRIPTION
added a sentry output plugin which supports the Writer interface for shared UDP connections.

Things to note:
- Raven - the Sentry client is the one that specifies where the final messages get routed, so there is no Sentry DSN in the configstruct for this output plugin.  The writer has a map of host/port->Connection objects.  This is managed by decoding the DSN per message and creating a new UDP socket if needed and stuffing it into the map.

I've tested this against metlog-py/heka branch and Sentry 5.0.13
