### PR TITLE
Feature/sentry cleanup

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -37,20 +37,12 @@ func hmac_sha1(message, key []byte) string {
 type SentryMsg struct {
 	encoded_payload string
 
-	epoch_ts64 float64
-	epoch_time time.Time
-	str_ts     string
+	// needed for auth and signature methods
+	str_ts string
 
-	dsn        string
-	parsed_dsn *url.URL
-
-	auth_header  string
+	parsed_dsn   *url.URL
 	dsn_password string
-
-	prep_error error
-	prep_bool  bool
-
-	data_packet []byte
+	data_packet  []byte
 }
 
 type SentryOutputWriter struct {
@@ -58,45 +50,25 @@ type SentryOutputWriter struct {
 	udpMap map[string]net.Conn
 }
 
-func get_auth_header(protocol float32, signature string, timestamp string, client_id string, api_key string) string {
+func (self *SentryMsg) get_auth_header(protocol float32, client_id string) string {
 	header_tmpl := "Sentry sentry_timestamp=%s, sentry_client=%s, sentry_version=%0.1f, sentry_key=%s"
-	return fmt.Sprintf(header_tmpl, timestamp, client_id, protocol, api_key)
+	return fmt.Sprintf(header_tmpl, self.str_ts, client_id, protocol, self.parsed_dsn.User.Username())
 }
 
-func get_signature(message string, str_ts string, key string) string {
-	return hmac_sha1([]byte(fmt.Sprintf("%s %s", str_ts, message)), []byte(key))
-}
-
-type SentryOutError struct {
-	When time.Time
-	What string
-}
-
-func (e SentryOutError) Error() string {
-	return fmt.Sprintf("%v: %v", e.When, e.What)
-}
-
-type MissingPassword struct {
-}
-
-func (e MissingPassword) Error() string {
-	return "No password was found in the DSN URI"
+func (self *SentryMsg) get_signature() string {
+	return hmac_sha1([]byte(fmt.Sprintf("%s %s", self.str_ts, self.encoded_payload)), []byte(self.dsn_password))
 }
 
 func (self *SentryMsg) compute_auth_header() (string, error) {
 
-	self.dsn_password, self.prep_bool = self.parsed_dsn.User.Password()
-	if !self.prep_bool {
-		return "", MissingPassword{}
+	var prep_bool bool
+
+	self.dsn_password, prep_bool = self.parsed_dsn.User.Password()
+	if !prep_bool {
+		return "", fmt.Errorf("No password was found in the DSN URI")
 	}
 
-	self.str_ts = self.epoch_time.Format(time.RFC3339Nano)
-
-	return get_auth_header(2.0,
-		get_signature(self.encoded_payload, self.str_ts, self.dsn_password),
-		self.str_ts,
-		"raven-go/1.0",
-		self.parsed_dsn.User.Username()), nil
+	return self.get_auth_header(2.0, "raven-go/1.0"), nil
 }
 
 type SentryOutputWriterConfig struct {
@@ -128,31 +100,38 @@ func (self *SentryOutputWriter) ZeroOutData(outData interface{}) {
 
 func (self *SentryOutputWriter) PrepOutData(pack *pipeline.PipelinePack, outData interface{}, timeout *time.Duration) error {
 
+	var prep_error error
+	var prep_bool bool
+	var epoch_ts64 float64
+	var epoch_time time.Time
+	var auth_header string
+	var dsn string
+
 	sentryMsg := outData.(*SentryMsg)
 	sentryMsg.encoded_payload = pack.Message.Payload
-	sentryMsg.epoch_ts64, sentryMsg.prep_bool = pack.Message.Fields["epoch_timestamp"].(float64)
+	epoch_ts64, prep_bool = pack.Message.Fields["epoch_timestamp"].(float64)
 
-	if !sentryMsg.prep_bool {
-		return SentryOutError{time.Now(), "Error parsing epoch_timestamp"}
+	if !prep_bool {
+		return fmt.Errorf("Error parsing epoch_timestamp")
 	}
 
-	sentryMsg.epoch_time = time.Unix(int64(sentryMsg.epoch_ts64),
-		int64((sentryMsg.epoch_ts64-float64(int64(sentryMsg.epoch_ts64)))*1e9))
+	epoch_time = (time.Unix(int64(epoch_ts64), int64((epoch_ts64-float64(int64(epoch_ts64)))*1e9)))
+	sentryMsg.str_ts = epoch_time.Format(time.RFC3339Nano)
 
-	sentryMsg.dsn = pack.Message.Fields["dsn"].(string)
+	dsn = pack.Message.Fields["dsn"].(string)
 
-	sentryMsg.parsed_dsn, sentryMsg.prep_error = url.Parse(sentryMsg.dsn)
-	if sentryMsg.prep_error != nil {
-		return sentryMsg.prep_error
+	sentryMsg.parsed_dsn, prep_error = url.Parse(dsn)
+	if prep_error != nil {
+		return fmt.Errorf("Error parsing DSN from sentry message")
 	}
 
-	sentryMsg.auth_header, sentryMsg.prep_error = sentryMsg.compute_auth_header()
+	auth_header, prep_error = sentryMsg.compute_auth_header()
 
-	if sentryMsg.prep_error != nil {
-		return sentryMsg.prep_error
+	if prep_error != nil {
+		return fmt.Errorf("Error computing authentication header from sentry message")
 	}
 
-	sentryMsg.data_packet = []byte(fmt.Sprintf("%s\n\n%s", sentryMsg.auth_header, sentryMsg.encoded_payload))
+	sentryMsg.data_packet = []byte(fmt.Sprintf("%s\n\n%s", auth_header, sentryMsg.encoded_payload))
 	return nil
 }
 
@@ -171,7 +150,7 @@ func (self *SentryOutputWriter) Write(outData interface{}) (err error) {
 	socket, host_ok = self.udpMap[udp_addr_str]
 	if !host_ok {
 		if len(self.udpMap) > self.config.MaxUdpSockets {
-			return SentryOutError{time.Now(), "Maximum number of UDP sockets reached."}
+			return fmt.Errorf("Maximum number of UDP sockets reached.")
 		}
 
 		udp_addr, socket_err = net.ResolveUDPAddr("udp", udp_addr_str)
@@ -181,7 +160,7 @@ func (self *SentryOutputWriter) Write(outData interface{}) (err error) {
 
 		socket, socket_err = net.DialUDP("udp", nil, udp_addr)
 		if socket_err != nil {
-			return SentryOutError{time.Now(), "Error while dialing the UDP socket"}
+			return fmt.Errorf("Error while dialing the UDP socket")
 		}
 		self.udpMap[sentryMsg.parsed_dsn.Host] = socket
 	}

--- a/sentry.go
+++ b/sentry.go
@@ -15,9 +15,6 @@
 package heka_mozsvc_plugins
 
 import (
-	"crypto/hmac"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"github.com/mozilla-services/heka/pipeline"
 	"net"
@@ -30,15 +27,6 @@ const (
 	raven_client_id    = "raven-go/1.0"
 	raven_protocol_rev = 2.0
 )
-
-// CheckMAC returns true if messageMAC is a valid HMAC tag for
-// message.
-func hmac_sha1(message, key []byte) string {
-	mac := hmac.New(sha1.New, key)
-	mac.Write(message)
-	expectedMAC := mac.Sum(nil)
-	return hex.EncodeToString(expectedMAC)
-}
 
 type SentryMsg struct {
 	encoded_payload string
@@ -106,7 +94,7 @@ func (self *SentryOutputWriter) PrepOutData(pack *pipeline.PipelinePack, outData
 		return fmt.Errorf("Error parsing DSN from sentry message")
 	}
 
-	auth_header = fmt.Sprintf(auth_header_tmpl, str_ts, raven_client_id, raven_protocol_rev, self.parsed_dsn.User.Username())
+	auth_header = fmt.Sprintf(auth_header_tmpl, str_ts, raven_client_id, raven_protocol_rev, sentryMsg.parsed_dsn.User.Username())
 	sentryMsg.data_packet = []byte(fmt.Sprintf("%s\n\n%s", auth_header, sentryMsg.encoded_payload))
 	return nil
 }

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -15,43 +15,41 @@
 package heka_mozsvc_plugins
 
 import (
+	"fmt"
+	"github.com/mozilla-services/heka/pipeline"
 	gs "github.com/rafrombrc/gospec/src/gospec"
 )
 
+const (
+	DSN      = "udp://username:password@localhost:9001/2"
+	PAYLOAD  = "not_real_encoded_data"
+	EPOCH_TS = 1358969429.508007
+)
+
+func getSentryPack() *pipeline.PipelinePack {
+	pipelinePack := getTestPipelinePack()
+	pipelinePack.Message.Type = "sentry"
+	pipelinePack.Message.Fields = make(map[string]interface{})
+	pipelinePack.Message.Fields["epoch_timestamp"] = EPOCH_TS
+	pipelinePack.Message.Fields["dsn"] = DSN
+	pipelinePack.Message.Payload = PAYLOAD
+	pipelinePack.Decoded = true
+	return pipelinePack
+}
+
 func SentryOutputSpec(c gs.Context) {
-	c.Specify("check that hmac hashes are correct", func() {
+	c.Specify("verify data_packet bytes", func() {
+		var outData *SentryMsg
+		pack := getSentryPack()
+		expected := fmt.Sprintf("Sentry sentry_timestamp=2013-01-23T14:30:29.508007049-05:00, sentry_client=raven-go/1.0, sentry_version=2.0, sentry_key=username\n\n%s", PAYLOAD)
 
-		// The following hexdigest was verified using a Python
-		// hmac-sha1 snippet:
-		//      hmac.new('this is the key', 'foobar', sha1).hexdigest()
-		//      'c7cbdca495adb024647b64123ef8203ae333f0d6'
-		expected_hexdigest := "c7cbdca495adb024647b64123ef8203ae333f0d6"
+		writer_ptr := &SentryOutputWriter{}
+		writer_ptr.Init(writer_ptr.ConfigStruct())
+		outData = writer_ptr.MakeOutData().(*SentryMsg)
 
-		actual_hexdigest := hmac_sha1([]byte("foobar"), []byte("this is the key"))
-		c.Expect(actual_hexdigest, gs.Equals, expected_hexdigest)
-	})
-
-	c.Specify("check auth header", func() {
-		actual_header := get_auth_header(2.0, "some_sig", "some_time", "some_client", "some_api_key")
-		expected_header := "Sentry sentry_timestamp=some_time, sentry_client=some_client, sentry_version=2.0, sentry_key=some_api_key"
-		c.Expect(actual_header, gs.Equals, expected_header)
-	})
-
-	c.Specify("check signature", func() {
-		/*
-					The expected_sig here is computed using:
-
-			        In [8]: def getsig(m, t, k):
-			           ...:   return hmac.new(k, '%s %s' % (t, m), sha1).hexdigest()
-			           ...:
-
-					In [9]: getsig('a message', 'some_time', 'some_api_key')
-					Out[9]: 'c05d61d5a04b6b37e122792b2eb9ccc6436441dc'
-		*/
-		actual_sig := get_signature("a message", "some_time", "some_api_key")
-		expected_sig := "c05d61d5a04b6b37e122792b2eb9ccc6436441dc"
-
-		c.Expect(actual_sig, gs.Equals, expected_sig)
+		writer_ptr.PrepOutData(pack, outData, nil)
+		actual := string(outData.data_packet)
+		c.Expect(actual, gs.Equals, expected)
 	})
 
 }

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -41,15 +41,53 @@ func SentryOutputSpec(c gs.Context) {
 	c.Specify("verify data_packet bytes", func() {
 		var outData *SentryMsg
 		pack := getSentryPack()
+		writer_ptr := &SentryOutputWriter{}
+		writer_ptr.Init(writer_ptr.ConfigStruct())
+		outData = writer_ptr.MakeOutData().(*SentryMsg)
+		err := writer_ptr.PrepOutData(pack, outData, nil)
+
+		c.Expect(err, gs.Equals, nil)
+
+		actual := string(outData.data_packet)
 		expected := fmt.Sprintf("Sentry sentry_timestamp=2013-01-23T14:30:29.508007049-05:00, sentry_client=raven-go/1.0, sentry_version=2.0, sentry_key=username\n\n%s", PAYLOAD)
 
+		c.Expect(actual, gs.Equals, expected)
+	})
+
+	c.Specify("missing or invalid epoch_timestamp doesn't kill process", func() {
+		var outData *SentryMsg
+		var err error
+
+		pack := getSentryPack()
 		writer_ptr := &SentryOutputWriter{}
 		writer_ptr.Init(writer_ptr.ConfigStruct())
 		outData = writer_ptr.MakeOutData().(*SentryMsg)
 
-		writer_ptr.PrepOutData(pack, outData, nil)
-		actual := string(outData.data_packet)
-		c.Expect(actual, gs.Equals, expected)
+		delete(pack.Message.Fields, "epoch_timestamp")
+		err = writer_ptr.PrepOutData(pack, outData, nil)
+		c.Expect(err.Error(), gs.Equals, "Error: no epoch_timestamp was found in Fields")
+
+		pack.Message.Fields["epoch_timestamp"] = "foo"
+		err = writer_ptr.PrepOutData(pack, outData, nil)
+		c.Expect(err.Error(), gs.Equals, "Error: epoch_timestamp isn't a float64")
+	})
+
+	c.Specify("missing or invalid dsn doesn't kill process", func() {
+		var outData *SentryMsg
+		var err error
+
+		pack := getSentryPack()
+		writer_ptr := &SentryOutputWriter{}
+		writer_ptr.Init(writer_ptr.ConfigStruct())
+		outData = writer_ptr.MakeOutData().(*SentryMsg)
+		delete(pack.Message.Fields, "dsn")
+
+		err = writer_ptr.PrepOutData(pack, outData, nil)
+		c.Expect(err.Error(), gs.Equals, "Error: no dsn was found in Fields")
+
+		pack.Message.Fields["dsn"] = 42
+		err = writer_ptr.PrepOutData(pack, outData, nil)
+		c.Expect(err.Error(), gs.Equals, "Error: dsn isn't a string")
 	})
 
 }


### PR DESCRIPTION
So none of the signature code is actually used, so all the hmac-sha1 code went away.  

The auth_header code simplified down to what amounts to a sprintf call that just encodes the DSN username.  The DSN password isn't actually used anywhere.

I also removed a bunch of attributes from the SentryMsg struct as they aren't necessary.

This code will need new tests against the sentry output, but I've verified that it does work in a full stack.
