### PR TITLE
sentry: use HTTP instead of UDP. Fixes #22

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -21,11 +21,6 @@ import (
 	"github.com/mozilla-services/heka/pipeline"
 )
 
-const (
-	raven_client_id    = "raven-go/1.0"
-	raven_protocol_rev = 2.0
-)
-
 type SentryMsg struct {
 	encodedPayload string
 	dsn            string

--- a/sentry.go
+++ b/sentry.go
@@ -70,9 +70,7 @@ func (so *SentryOutput) prepSentryMsg(pack *pipeline.PipelinePack,
 }
 
 func (so *SentryOutput) getClient(dsn string) (client *raven.Client, err error) {
-	var (
-		ok bool
-	)
+	var ok bool
 	if client, ok = so.clientMap[dsn]; !ok {
 		client, err = raven.NewClient(dsn, nil)
 	}


### PR DESCRIPTION
One thing that's not supported right now that might be good to support at some point in the future is sending more structured data to Sentry. Right now I just send the payload as a string, since it looks like that's what was sent before, but I think ideally this would send the message fields.
