### PR TITLE
Allow setting encoder and Dsn for SentryOutput

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -16,14 +16,15 @@
 package heka_mozsvc_plugins
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/getsentry/raven-go"
 	"github.com/mozilla-services/heka/pipeline"
 )
 
 type SentryMsg struct {
-	encodedPayload string
-	dsn            string
+	dsn string
 }
 
 type SentryOutput struct {
@@ -57,7 +58,11 @@ func (so *SentryOutput) prepSentryMsg(pack *pipeline.PipelinePack,
 		tmp interface{}
 	)
 
-	sentryMsg.encodedPayload = pack.Message.GetPayload()
+	// Take dsn value from config if it is set.
+	if so.config.Dsn != "" {
+		sentryMsg.dsn = so.config.Dsn
+		return
+	}
 
 	if tmp, ok = pack.Message.GetFieldValue("dsn"); !ok {
 		return fmt.Errorf("no `dsn` field")
@@ -79,14 +84,25 @@ func (so *SentryOutput) getClient(dsn string) (client *raven.Client, err error) 
 
 func (so *SentryOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) (err error) {
 	var (
-		e      error
-		pack   *pipeline.PipelinePack
-		client *raven.Client
+		e        error
+		pack     *pipeline.PipelinePack
+		client   *raven.Client
+		contents []byte
 	)
 
+	if or.Encoder() == nil {
+		return errors.New("Encoder required for SentryOutput")
+	}
 	sentryMsg := &SentryMsg{}
 
 	for pack = range or.InChan() {
+		contents, e = or.Encode(pack)
+		if e != nil {
+			or.LogError(fmt.Errorf("Error encoding message: %s", e))
+			pack.Recycle()
+			continue
+		}
+
 		e = so.prepSentryMsg(pack, sentryMsg)
 		pack.Recycle()
 		if e != nil {
@@ -94,11 +110,11 @@ func (so *SentryOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) (
 			continue
 		}
 
-		if client, err = so.getClient(sentryMsg.dsn); err != nil {
+		if client, e = so.getClient(sentryMsg.dsn); e != nil {
 			or.LogError(e)
 			continue
 		}
-		client.CaptureMessage(sentryMsg.encodedPayload, nil)
+		client.CaptureMessage(string(contents), nil)
 	}
 	return
 }

--- a/sentry.go
+++ b/sentry.go
@@ -35,12 +35,14 @@ type SentryOutput struct {
 type SentryOutputConfig struct {
 	MaxSentryBytes int    `toml:"max_sentry_bytes"`
 	Matcher        string `toml:"message_matcher"`
+	Dsn            string `toml:"dsn"`
 }
 
 func (so *SentryOutput) ConfigStruct() interface{} {
 	return &SentryOutputConfig{
 		MaxSentryBytes: 64000,
 		Matcher:        "Type == 'sentry'",
+		Dsn:            "",
 	}
 }
 
@@ -70,7 +72,6 @@ func (so *SentryOutput) prepSentryMsg(pack *pipeline.PipelinePack,
 	if sentryMsg.dsn, ok = tmp.(string); !ok {
 		return fmt.Errorf("`dsn` isn't a string")
 	}
-
 	return
 }
 

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -47,7 +47,6 @@ func getSentryPackWithoutDsn() (pack *pipeline.PipelinePack) {
 	pack = pipeline.NewPipelinePack(recycleChan)
 	pack.Message.SetType("sentry")
 	pack.Message.SetPayload(PAYLOAD)
-	pack.Decoded = true
 	pack.Message.SetTimestamp(int64(EPOCH_TS * 1e9))
 	return
 }

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
+	"github.com/mozilla-services/heka/plugins"
 	plugins_ts "github.com/mozilla-services/heka/plugins/testsupport"
 	"github.com/rafrombrc/gomock/gomock"
 	gs "github.com/rafrombrc/gospec/src/gospec"
@@ -41,9 +42,21 @@ func getSentryPack() (pack *pipeline.PipelinePack) {
 	return
 }
 
+func getSentryPackWithoutDsn() (pack *pipeline.PipelinePack) {
+	recycleChan := make(chan *pipeline.PipelinePack, 1)
+	pack = pipeline.NewPipelinePack(recycleChan)
+	pack.Message.SetType("sentry")
+	pack.Message.SetPayload(PAYLOAD)
+	pack.Decoded = true
+	pack.Message.SetTimestamp(int64(EPOCH_TS * 1e9))
+	return
+}
+
 func SentryOutputSpec(c gs.Context) {
 
 	t := new(pipeline_ts.SimpleT)
+	encoder := new(plugins.PayloadEncoder)
+	encoder.Init(new(plugins.PayloadEncoderConfig))
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -75,7 +88,9 @@ func SentryOutputSpec(c gs.Context) {
 			oth := plugins_ts.NewOutputTestHelper(ctrl)
 			inChan := make(chan *pipeline.PipelinePack, 1)
 			oth.MockOutputRunner.EXPECT().InChan().Return(inChan)
-
+			oth.MockOutputRunner.EXPECT().Encoder().Return(encoder)
+			oth.MockOutputRunner.EXPECT().Encode(gomock.Any()).Return(
+				[]byte(PAYLOAD), nil)
 			pack := getSentryPack()
 			inChan <- pack
 			close(inChan)
@@ -84,4 +99,23 @@ func SentryOutputSpec(c gs.Context) {
 		})
 	})
 
+	c.Specify("A SentryOutput with dsn config", func() {
+		output := new(SentryOutput)
+		conf := output.ConfigStruct().(*SentryOutputConfig)
+		conf.Dsn = DSN
+		output.Init(conf)
+		c.Specify("calls CaptureMessage with the payload when it has a dsn", func() {
+			oth := plugins_ts.NewOutputTestHelper(ctrl)
+			inChan := make(chan *pipeline.PipelinePack, 1)
+			oth.MockOutputRunner.EXPECT().InChan().Return(inChan)
+			oth.MockOutputRunner.EXPECT().Encoder().Return(encoder)
+			oth.MockOutputRunner.EXPECT().Encode(gomock.Any()).Return(
+				[]byte(PAYLOAD), nil)
+			pack := getSentryPackWithoutDsn()
+			inChan <- pack
+			close(inChan)
+
+			output.Run(oth.MockOutputRunner, oth.MockHelper)
+		})
+	})
 }


### PR DESCRIPTION
This change allows setting an encoder to use for SentryOutput.  If none is provided, it defaults to a PayloadEncoder which preserves it's old behavior of just sending the payload.

It also allows you to optionally set a Dsn in the SentryOutput config instead of requiring it to be a field on the message.
